### PR TITLE
Add teacher admin mode for activity enrollment actions

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +20,19 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+teachers_file = current_dir / "teachers.json"
+
+
+def load_teacher_credentials() -> dict:
+    """Load teacher credentials from a JSON file in the project root."""
+    with teachers_file.open("r", encoding="utf-8") as file:
+        data = json.load(file)
+    return data.get("teachers", {})
+
+
+teacher_credentials = load_teacher_credentials()
+active_teacher_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -88,9 +103,55 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def teacher_login(username: str, password: str):
+    """Authenticate teachers and issue a lightweight in-memory session token."""
+    expected_password = teacher_credentials.get(username)
+    if expected_password is None or expected_password != password:
+        raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    token = secrets.token_urlsafe(24)
+    active_teacher_sessions[token] = username
+    return {"message": "Teacher login successful", "token": token, "username": username}
+
+
+@app.post("/auth/logout")
+def teacher_logout(x_teacher_token: str | None = Header(default=None)):
+    """Invalidate the teacher session token."""
+    if x_teacher_token and x_teacher_token in active_teacher_sessions:
+        active_teacher_sessions.pop(x_teacher_token)
+    return {"message": "Logged out"}
+
+
+@app.get("/auth/me")
+def get_authenticated_teacher(x_teacher_token: str | None = Header(default=None)):
+    """Return current authenticated teacher for UI session restoration."""
+    username = active_teacher_sessions.get(x_teacher_token or "")
+    if not username:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return {"username": username}
+
+
+def require_teacher_token(x_teacher_token: str | None) -> str:
+    """Ensure the request is from an authenticated teacher."""
+    username = active_teacher_sessions.get(x_teacher_token or "")
+    if not username:
+        raise HTTPException(
+            status_code=401,
+            detail="Teacher authentication required for this action"
+        )
+    return username
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    x_teacher_token: str | None = Header(default=None)
+):
     """Sign up a student for an activity"""
+    require_teacher_token(x_teacher_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +172,14 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    x_teacher_token: str | None = Header(default=None)
+):
     """Unregister a student from an activity"""
+    require_teacher_token(x_teacher_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,97 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userIconBtn = document.getElementById("user-icon-btn");
+  const userMenu = document.getElementById("user-menu");
+  const authStatus = document.getElementById("auth-status");
+  const authActionBtn = document.getElementById("auth-action-btn");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLoginBtn = document.getElementById("cancel-login");
+  const teacherUsernameInput = document.getElementById("teacher-username");
+  const teacherPasswordInput = document.getElementById("teacher-password");
+
+  let teacherToken = localStorage.getItem("teacherToken") || "";
+  let teacherUsername = localStorage.getItem("teacherUsername") || "";
+
+  function showMessage(text, type = "info") {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function isTeacherLoggedIn() {
+    return Boolean(teacherToken);
+  }
+
+  function setAuthenticatedState(token, username) {
+    teacherToken = token;
+    teacherUsername = username;
+    localStorage.setItem("teacherToken", token);
+    localStorage.setItem("teacherUsername", username);
+    updateAuthUI();
+  }
+
+  function clearAuthenticatedState() {
+    teacherToken = "";
+    teacherUsername = "";
+    localStorage.removeItem("teacherToken");
+    localStorage.removeItem("teacherUsername");
+    updateAuthUI();
+  }
+
+  function updateAuthUI() {
+    const loggedIn = isTeacherLoggedIn();
+    signupForm.querySelectorAll("input, select, button").forEach((field) => {
+      field.disabled = !loggedIn;
+    });
+
+    if (loggedIn) {
+      authStatus.textContent = `Teacher mode: ${teacherUsername}`;
+      authActionBtn.textContent = "Logout";
+    } else {
+      authStatus.textContent = "Student mode";
+      authActionBtn.textContent = "Login";
+    }
+  }
+
+  async function validateStoredSession() {
+    if (!teacherToken) {
+      updateAuthUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: {
+          "X-Teacher-Token": teacherToken,
+        },
+      });
+
+      if (!response.ok) {
+        clearAuthenticatedState();
+      }
+    } catch (error) {
+      clearAuthenticatedState();
+      console.error("Failed to validate session", error);
+    }
+
+    updateAuthUI();
+  }
+
+  function openLoginModal() {
+    loginModal.classList.remove("hidden");
+    teacherUsernameInput.focus();
+  }
+
+  function closeLoginModal() {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +121,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span><button class="delete-btn ${
+                        isTeacherLoggedIn() ? "" : "hidden"
+                      }" data-activity="${name}" data-email="${email}">❌</button></li>`
                   )
                   .join("")}
               </ul>
@@ -50,10 +143,10 @@ document.addEventListener("DOMContentLoaded", () => {
         activitiesList.appendChild(activityCard);
 
         // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        activitySelect.appendChild(option);
+          const option = document.createElement("option");
+          option.value = name;
+          option.textContent = name;
+          activitySelect.appendChild(option);
       });
 
       // Add event listeners to delete buttons
@@ -69,6 +162,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!isTeacherLoggedIn()) {
+      showMessage("Only logged-in teachers can unregister students.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,32 +178,27 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        if (response.status === 401) {
+          clearAuthenticatedState();
+        }
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -113,6 +206,11 @@ document.addEventListener("DOMContentLoaded", () => {
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!isTeacherLoggedIn()) {
+      showMessage("Only logged-in teachers can register students.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +222,104 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        if (response.status === 401) {
+          clearAuthenticatedState();
+        }
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  // User menu interactions
+  userIconBtn.addEventListener("click", () => {
+    userMenu.classList.toggle("hidden");
+  });
+
+  document.addEventListener("click", (event) => {
+    const clickedInsideMenu = event.target.closest("#user-menu-container");
+    if (!clickedInsideMenu) {
+      userMenu.classList.add("hidden");
+    }
+  });
+
+  authActionBtn.addEventListener("click", async () => {
+    if (!isTeacherLoggedIn()) {
+      openLoginModal();
+      return;
+    }
+
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: {
+          "X-Teacher-Token": teacherToken,
+        },
+      });
+    } catch (error) {
+      console.error("Logout request failed", error);
+    }
+
+    clearAuthenticatedState();
+    fetchActivities();
+    showMessage("Logged out. Student mode is active.", "info");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = teacherUsernameInput.value.trim();
+    const password = teacherPasswordInput.value;
+
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        {
+          method: "POST",
+        }
+      );
+
+      const result = await response.json();
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      setAuthenticatedState(result.token, result.username);
+      closeLoginModal();
+      fetchActivities();
+      showMessage(`Logged in as ${result.username}`, "success");
+    } catch (error) {
+      showMessage("Failed to login. Please try again.", "error");
+      console.error("Login failed", error);
+    }
+  });
+
+  cancelLoginBtn.addEventListener("click", closeLoginModal);
+
+  loginModal.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      closeLoginModal();
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  validateStoredSession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,13 @@
   </head>
   <body>
     <header>
+      <div id="user-menu-container">
+        <button id="user-icon-btn" class="icon-btn" aria-label="User menu">👤</button>
+        <div id="user-menu" class="user-menu hidden">
+          <p id="auth-status">Student mode</p>
+          <button id="auth-action-btn" type="button">Login</button>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -23,6 +30,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-only-note" class="info-text">
+          Teacher login is required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -44,6 +54,26 @@
     <footer>
       <p>&copy; 2026 Mergington High School</p>
     </footer>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <h3 id="login-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required placeholder="teacher username" />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required placeholder="teacher password" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button id="cancel-login" type="button" class="secondary-btn">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,56 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+#user-menu-container {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.icon-btn {
+  background-color: #ffffff;
+  color: #1a237e;
+  border: 1px solid #d0d0d0;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  background-color: #f3f6ff;
+}
+
+.user-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 8px;
+  background-color: #fff;
+  color: #333;
+  min-width: 180px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+  padding: 10px;
+  z-index: 50;
+}
+
+.user-menu p {
+  margin-bottom: 8px;
+  font-size: 14px;
 }
 
 header h1 {
@@ -134,6 +178,12 @@ section h3 {
   margin-bottom: 15px;
 }
 
+.info-text {
+  margin-bottom: 14px;
+  font-size: 14px;
+  color: #0c5460;
+}
+
 .form-group label {
   display: block;
   margin-bottom: 5px;
@@ -190,6 +240,39 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  width: min(92vw, 420px);
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.secondary-btn {
+  background-color: #e0e0e0;
+  color: #333;
+}
+
+.secondary-btn:hover {
+  background-color: #cfcfcf;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,7 @@
+{
+  "teachers": {
+    "ms.adams": "algebra2026",
+    "mr.lee": "science2026",
+    "coach.carter": "sports2026"
+  }
+}


### PR DESCRIPTION
## Summary
Implements Admin Mode so only logged-in teachers can register and unregister students in activities.

## What changed
- Added teacher authentication endpoints in backend:
  - `POST /auth/login`
  - `POST /auth/logout`
  - `GET /auth/me`
- Added token validation for protected actions:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Added teacher credentials file:
  - `src/teachers.json`
- Added frontend auth UX:
  - User icon in top-right corner
  - Login/logout menu
  - Login modal with username/password
  - Student mode remains read-only for participant operations

## Validation
- Unauthorized signup returns 401
- Teacher login returns 200
- Authorized signup/unregister return 200
- After logout, protected actions return 401 again

## Related issue
Closes #5